### PR TITLE
Zod type generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
-        "chokidar": "^3.5.3"
+        "chokidar": "^3.5.3",
+        "zod": "^3.22.4",
+        "zod-to-ts": "^1.2.0"
       },
       "devDependencies": {
         "@types/node": "^20.4.5",
@@ -2097,7 +2099,6 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2660,6 +2661,23 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-ts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+      "peerDependencies": {
+        "typescript": "^4.9.4 || ^5.0.2",
+        "zod": "^3"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
   },
   "dependencies": {
     "chalk": "^5.3.0",
-    "chokidar": "^3.5.3"
+    "chokidar": "^3.5.3",
+    "zod": "^3.22.4",
+    "zod-to-ts": "^1.2.0"
   }
 }

--- a/src/jit-env.ts
+++ b/src/jit-env.ts
@@ -273,8 +273,14 @@ export default class JitEnv {
       /\n/g,
       `\n${indentPre}`,
     )}`;
-    if (envData !== undefined) {
-      const envString = Buffer.from(JSON.stringify(envData)).toString("base64");
+    const validationResult = this.schema?.safeParse(envData);
+    if (
+      envData !== undefined &&
+      (!validationResult || validationResult.success)
+    ) {
+      const envString = Buffer.from(
+        JSON.stringify(validationResult ? validationResult.data : envData),
+      ).toString("base64");
 
       injectable = injectable.replace(/___INJECT_ENV___/, envString);
     }


### PR DESCRIPTION
Adds a `schema` option to the plugin options, where a zod schema can be passed. This leads to:
1. The zod schema being used to generate the type of the environment.
2. The environment from the json files is parsed by the schema before getting injected.